### PR TITLE
Modify the installer so that the Dispose method is executed, etc.

### DIFF
--- a/Assets/Scripts/Installers/MainSceneInstaller.cs
+++ b/Assets/Scripts/Installers/MainSceneInstaller.cs
@@ -20,13 +20,7 @@ namespace WatermelonGameClone.Installers
 
         public override void InstallBindings()
         {
-            // Presenter
-            Container
-                .BindInterfacesTo<MainScenePresenter>()
-                .AsSingle()
-                .NonLazy();
-
-            //Model
+            // Services
             Container
                 .Bind<IMergeItemIndexService>()
                 .To<MergeItemIndexService>()
@@ -34,8 +28,7 @@ namespace WatermelonGameClone.Installers
                 .AsSingle();
 
             Container
-                .Bind<IMergeItemUseCase>()
-                .To<MergeItemUseCase>()
+                .BindInterfacesTo<MergeItemUseCase>()
                 .FromNew()
                 .AsSingle();
 
@@ -140,6 +133,12 @@ namespace WatermelonGameClone.Installers
                 .To<ScreenshotHandler>()
                 .FromComponentInNewPrefab(_screenshotHandler)
                 .AsSingle();
+
+            // Presenter
+            Container
+                .BindInterfacesTo<MainScenePresenter>()
+                .AsSingle()
+                .NonLazy();
         }
     }
 }

--- a/Assets/Scripts/Installers/ProjectInstaller.cs
+++ b/Assets/Scripts/Installers/ProjectInstaller.cs
@@ -18,7 +18,20 @@ namespace WatermelonGameClone.Installers
 
         public override void InstallBindings()
         {
-            // Common Model
+            // Commom Services
+            Container
+                .Bind<IScoreRankingService>()
+                .To<ScoreRankingService>()
+                .FromNew()
+                .AsSingle();
+
+            Container
+                .Bind<IScoreResetService>()
+                .To<ScoreResetService>()
+                .FromNew()
+                .AsSingle();
+            
+            // Common Repositories
             Container
                 .Bind<TimeSettings>()
                 .FromInstance(_timeSettings)
@@ -53,36 +66,6 @@ namespace WatermelonGameClone.Installers
                 .AsSingle();
 
             Container
-                .Bind<IGameStateUseCase>()
-                .To<GameStateUseCase>()
-                .FromNew()
-                .AsSingle();
-
-            Container
-                .Bind<IScoreUseCase>()
-                .To<ScoreUseCase>()
-                .FromNew()
-                .AsSingle();
-
-            Container
-                .Bind<ISoundUseCase>()
-                .To<SoundUseCase>()
-                .FromNew()
-                .AsSingle();
-
-            Container
-                .Bind<IScoreRankingService>()
-                .To<ScoreRankingService>()
-                .FromNew()
-                .AsSingle();
-
-            Container
-                .Bind<IScoreResetService>()
-                .To<ScoreResetService>()
-                .FromNew()
-                .AsSingle();
-
-            Container
                 .Bind<IScoreRepository>()
                 .To<JsonScoreRepository>()
                 .FromNew()
@@ -91,6 +74,22 @@ namespace WatermelonGameClone.Installers
             Container
                 .Bind<ISoundVolumeRepository>()
                 .To<JsonSoundVolumeRepository>()
+                .FromNew()
+                .AsSingle();
+
+            // Common UseCases
+            Container
+                .BindInterfacesTo<GameStateUseCase>()
+                .FromNew()
+                .AsSingle();
+
+            Container
+                .BindInterfacesTo<ScoreUseCase>()
+                .FromNew()
+                .AsSingle();
+
+            Container
+                .BindInterfacesTo<SoundUseCase>()
                 .FromNew()
                 .AsSingle();
 

--- a/Assets/Scripts/UseCase/UseCases/Common/GameStateUseCase.cs
+++ b/Assets/Scripts/UseCase/UseCases/Common/GameStateUseCase.cs
@@ -24,7 +24,7 @@ namespace WatermelonGameClone.UseCase
         public float TimeScaleGameStart { get; private set; }
         public float TimeScaleGameOver { get; private set; }
 
-        private ITimeSettingsRepository _timeSettingsRepository;
+        private readonly ITimeSettingsRepository _timeSettingsRepository;
         private CompositeDisposable _disposables;
 
         [Inject]

--- a/Assets/Scripts/UseCase/UseCases/Common/SoundUseCase.cs
+++ b/Assets/Scripts/UseCase/UseCases/Common/SoundUseCase.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 using System.Threading;
 using System.Collections.Generic;
@@ -8,11 +9,11 @@ using WatermelonGameClone.Domain;
 
 namespace WatermelonGameClone.UseCase
 {
-    public sealed class SoundUseCase : ISoundUseCase
+    public sealed class SoundUseCase : ISoundUseCase, IDisposable
     {
         private Dictionary<SoundEffect, AudioClip> _soundEffects;
-        private ISoundEffectsRepository _soundEffectsRepository;
-        private ISoundVolumeRepository _soundVolumeRepository;
+        private readonly ISoundEffectsRepository _soundEffectsRepository;
+        private readonly ISoundVolumeRepository _soundVolumeRepository;
         private AudioSource _audioSourceBgm;
         private AudioSource _audioSourceSe;
 
@@ -43,6 +44,13 @@ namespace WatermelonGameClone.UseCase
         public async UniTask InitializeAsync(CancellationToken ct)
         {
             await LoadSoundSettingsAsync(ct);
+        }
+
+        public void Dispose()
+        {
+            _audioSourceSe = null;
+            _audioSourceBgm = null;
+            _soundEffects = null;
         }
 
         private async UniTask LoadSoundSettingsAsync(CancellationToken ct)

--- a/Assets/Scripts/UseCase/UseCases/MergeItemUseCase.cs
+++ b/Assets/Scripts/UseCase/UseCases/MergeItemUseCase.cs
@@ -7,7 +7,7 @@ namespace WatermelonGameClone.UseCase
 {
     public sealed class MergeItemUseCase : IMergeItemUseCase, IDisposable
     {
-        private ReactiveProperty<int> _nextItemIndex;
+        private readonly ReactiveProperty<int> _nextItemIndex;
         public IReadOnlyReactiveProperty<int> NextItemIndex
             => _nextItemIndex.ToReadOnlyReactiveProperty();
 


### PR DESCRIPTION
Closes #17 

The lifetime of each instantiated use case class is managed by Zenject.   
Therefore, I modified the Zenject installer so that all interfaces are bound and the Dispose method is executed according to the lifecycle.  