### PR TITLE
Fixed: Add ScriptableObjectInstaller reference to MainScene

### DIFF
--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -261,7 +261,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 89715ad69b973a14899afa2c6730b30b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _scriptableObjectInstallers: []
+  _scriptableObjectInstallers:
+  - {fileID: 11400000, guid: 959e8f48a701cd54c971c25f31a48f8d, type: 2}
   _monoInstallers:
   - {fileID: 180661478}
   _installerPrefabs: []


### PR DESCRIPTION
Fixed an issue where the scriptable object installer reference was missing.